### PR TITLE
Add snap support

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,12 +75,19 @@
       ]
     },
     "linux": {
-      "target": ["deb", "snap"],
+      "target": [
+        "deb", 
+        "snap"
+      ],
       "maintainer": "dev@codefoxes.com"
     },
     "snap" : {
-      "plugs": ["default"],
-      "after": ["desktop-gtk2"]
+      "plugs": [
+        "default"
+      ],
+      "after": [
+        "desktop-gtk2"
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "chai-as-promised": "^5.3.0",
     "electron-bin-path": "^0.1.0",
     "electron-packager": "^7.7.0",
-    "electron-builder": "^7.9.0",
+    "electron-builder": "^19.53.0",
     "electron": "^1.3.5",
     "mocha": "^3.0.0",
     "spectron": "^3.3.0"
@@ -75,8 +75,12 @@
       ]
     },
     "linux": {
-      "target": "deb",
+      "target": ["deb", "snap"],
       "maintainer": "dev@codefoxes.com"
+    },
+    "snap" : {
+      "plugs": ["default"],
+      "after": ["desktop-gtk2"]
     }
   }
 }


### PR DESCRIPTION
Hi! I put together this PR to add a [snap](https://snapcraft.io) package. I've tested it on Ubuntu 16.04, but it should work just as well on Ubuntu 17.10, Ubuntu 14.04, Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and ```npm run build``` it will create ```dist/firebase-admin_1.0.1_amd64.snap```.

Copy this to a Linux system, [enable snap support](https://docs.snapcraft.io/core/install), then run: 
```sudo snap install firebase-admin_1.0.1_amd64.snap --dangerous``` 

Run with ```firebase-admin``` or find it in the launcher.

If you create a developer account and push this to the Snap Store, it can be discovered and installed through GNOME Software and [https://snapcraft.io/discover](https://snapcraft.io/discover/). To create the developer account, [sign up here](https://dashboard.snapcraft.io/dev/account/), then [register the "firebase-admin" name](https://dashboard.snapcraft.io/register-snap/?name=firebase-admin).

You'll need the snapcraft command to push the snap file to the store.

If you're on a Mac, you can ```brew install snapcraft```
If you're on Linux, it's ```sudo snap install --classic snapcraft```
Then you can push Ling out with:
```snapcraft push  firebase-admin_1.0.1_amd64.snap --release stable```