### PR TITLE
A few usability improvements when using Queries

### DIFF
--- a/create.html
+++ b/create.html
@@ -96,7 +96,7 @@
 <script>
 	const electron = require('electron').remote
 	const ipc = require('electron').ipcRenderer
-	const firebase = require("firebase")
+	const firebase = require("firebase-admin")
 	const writeFile = require('write-file-atomic')
 	require('electron').webFrame.setZoomLevelLimits(1, 1)
 </script>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 	<script>
 		const electron = require('electron').remote
 		const ipc = require('electron').ipcRenderer
-		const firebase = require("firebase")
+		const firebase = require("firebase-admin")
 		const writeFile = require('write-file-atomic')
 		const clipboard = electron.clipboard
 		//window.$ = window.jQuery = require('jquery')

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 </head>
 <body ng-app="fba" ng-controller="mainController" class="{{os}} index">
 	<div id="mainmenu">
-		<div class="titlebar" ng-if="titleBar">Firebase Admin</div>
+		<div class="titlebar" ng-if="titleBar">Firebase Admin<span ng-show="currentApp.name"> - {{currentApp.name}}</span></div>
 		<div class="icons">
 			<div class="icon" ng-click="listShown = true;">
 				<img class="logo" src="img/list.svg">

--- a/js/app.js
+++ b/js/app.js
@@ -182,6 +182,7 @@ var fba = angular.module('fba', ['ngRoute', 'angularResizable', 'ui.codemirror']
       $scope.currentApp = $scope.apps[id]
       $scope.update()
       dataBin.setData('openCon', openCon)
+      ipc.send('set-title', $scope.currentApp.name)
     } catch (err) {
       $scope.menuOverlay = false
       $scope.menuHidden = true

--- a/js/default-settings.json
+++ b/js/default-settings.json
@@ -1,5 +1,6 @@
 {
   "theme": "light",
   "fonts": "system",
-  "jsonTheme": "default"
+  "jsonTheme": "default",
+  "queryMethod": "on"
 }

--- a/js/settings.js
+++ b/js/settings.js
@@ -3,17 +3,23 @@ var fbaP = angular.module('fba-p', []).run(function () {
 
 .controller('settingsController', function ($scope, $timeout) {
   $scope.view = {}
-  $scope.view.theme = true
-  $scope.activeUrl = 'theme'
   $scope.saved = false
   $scope.jsonThemes = []
   $scope.items = [{
+      name: 'General',
+      url: 'general'
+  },
+  {
     name: 'Theme',
     url: 'theme'
   },{
     name: 'Fonts',
     url: 'fonts'
   }]
+
+  let defaultView = $scope.items[0]
+  $scope.view[defaultView.url] = true
+  $scope.activeUrl = defaultView.url
 
   const userPath = electron.app.getPath('userData')
   const fs = require('graceful-fs')

--- a/main.js
+++ b/main.js
@@ -92,6 +92,8 @@ ipc.on('show-context-menu', (e, args) => {
 
 ipc.on('reload-window', () => mainWindow.reload())
 
+ipc.on('set-title', function(e, newTitle) { mainWindow.setTitle(newTitle) })
+
 ipc.on('open-create-window', function (event) {
   createWindow('conWin', 'create.html', {parent: mainWindow, width: 600, height: 320})
 })

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "spectron": "^3.3.0"
   },
   "dependencies": {
-    "firebase": "^3.2.0",
+    "firebase-admin": "^5.12.0",
     "graceful-fs": "^4.1.4",
     "jquery": "^3.1.0",
     "write-file-atomic": "^1.1.4"

--- a/settings.html
+++ b/settings.html
@@ -18,6 +18,18 @@
 	</div>
 	<div class="admin-content">
 		<form class="form" ng-submit="save()" name="settings">
+			<section class="general" ng-show="view.general">
+				<div class="panel">
+					<div class="panel-heading">Query Method</div>
+					<div>Choose what method to use when retrieving data from a database reference object. Using <code>once</code> will retrieve the value once, while using <code>on</code> will continue to monitor changes to this reference and will reload the results if the real-time database detects a change.</div>
+					<div class="radio">
+						<div class="radio" ng-repeat="qType in ['on', 'once']" >
+							<input type="radio" name="queryMethod" ng-attr-id="queryMethod-{{qType}}" ng-model="form.queryMethod" ng-value="qType">
+							<label ng-attr-for="queryMethod-{{qType}}">{{qType}}</label>
+						</div>
+					</div>
+				</div>
+			</section>
 			<section class="theme" ng-show="view.theme">
 				<div class="panel">
 					<div class="panel-heading">Main Theme</div>

--- a/templates/main.html
+++ b/templates/main.html
@@ -1,7 +1,7 @@
 <section ng-hide="rootError" class="container content">
 	<form id="query-box" class="query-box" resizable r-directions="['bottom']">
 		<ui-codemirror id="query" ui-codemirror-opts="codeQueryOptions" ng-model="query"></ui-codemirror>
-		<button type="submit" class="button" ng-click="run()">Run</button>
+		<div class="loader" ng-show="queryRunning"></div><button type="submit" class="button" ng-click="run()" ng-disable="queryRunning">Run<span ng-show="queryRunning">ing...</span></button>
 	</form>
 	<div class="result-wrap">
 		<div class="result-mode">
@@ -23,7 +23,12 @@
 			</div>
 		</div>
 		<div class="result-view raw" ng-show="view.raw">
-			<div class="result" ng-repeat="result in results">{{result}}</div>
+			<div class="result-wrap">
+				<div class="result-mode" ng-show="results.length > 1">
+					<div class="icon" ng-repeat="result in results track by $index" ng-click="selectResult($index)" ng-class="{'active': selectedResult == $index}">{{$index+1}}</div>
+				</div>
+				<div class="result" ng-repeat="result in results track by $index" ng-show="selectedResult == $index">{{result}}</div>
+			</div>
 		</div>
 		<div class="copy-wrap" ng-click="copy()">
 			<img class="copy" src="img/copy.svg">


### PR DESCRIPTION
I had a few issues with the app, so I've created the following changes, hope you'll find them useful:
* added a new setting that allows the user to choose if to use `on` or `once` for default query
* improved the look of the query result pane when the user calls `console.log` multiple times. Now it shows each `result` in its own numbered tab
* Upgraded firebase to latest firebase-admin to prevent an error when calling `initializeApp()`
* Added the active Firebase connection name to the title and the Window drop-down menu to help know which connection you are on at the moment
* Made the queries run in an async call and refresh the UI to show a progress animation and message.

**_Note:_** The main reason for my changes was the fact that when using the Queries option against an active production database, the use of `on` caused my query window to keep changing every time the production database changed. Also with long queries, the UI felt frozen because the query happened directly in the ng-click event without allowing the UI to update.